### PR TITLE
fixed the font bug, also the double slash attached to each asset path

### DIFF
--- a/chkassets
+++ b/chkassets
@@ -2,7 +2,7 @@
 # Check for unused assets in flutter
 # And automate the removal of them optionally
 
-assets="assets/"
+assets="assets"
 YELLOW='\033[1;33m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -11,11 +11,19 @@ NC='\033[0m' # No Color
 while IFS= read -r -d '' file
 do
 	asset="$(basename "$file")"
-	if [ -n "$(find . -name "*.dart" -type f -print0 | xargs -0 grep -l -m 1\
-		"$asset")" ];
+
+	existInDartFiles="$(find . -name "*.dart" -type f -print0 | xargs -0 grep -l -m 1\
+		"$asset")"
+	existInPubspec="$(find . -name "pubspec.yaml" -type f -print0 | xargs -0 grep -l -m 1\
+		"$asset")"
+
+	# echo $existInPubspec
+	# echo ""
+	# echo $existInDartFiles
+	if [[ $existInDartFiles || $existInPubspec ]];
 	then
 		echo -n ""
-		#echo "Path is $file"
+		# echo "Path is $file"
 		echo -e "${GREEN}[$file]: ${YELLOW}$asset${NC} is being used"
 	else
 		echo -e "${RED}[$file]: ${NC}Deleting unused asset ${YELLOW}$asset"


### PR DESCRIPTION
while using the script, I discovered that all my font files were deleted.
The issue was that the script was not checking for my font path. because the font was not used like the other assets.
So I added an additional condition for the script to check for the font path in the pubspec file.
Also, the double slash attached to each asset path also fixed.